### PR TITLE
added explicit link to cblas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     packages:
       - libdlib-dev
       - libblas-dev
+      - libatlas-base-dev
       - liblapack-dev
       - libjpeg-turbo8-dev
 notifications:

--- a/face.go
+++ b/face.go
@@ -1,7 +1,7 @@
 package face
 
 // #cgo CXXFLAGS: -std=c++1z -Wall -O3 -DNDEBUG -march=native
-// #cgo LDFLAGS: -ldlib -lblas -llapack -ljpeg
+// #cgo LDFLAGS: -ldlib -lblas -lcblas -llapack -ljpeg
 // #include <stdlib.h>
 // #include <stdint.h>
 // #include "facerec.h"


### PR DESCRIPTION
It seems that Ubuntu includes the cblas symbols with the blas installation (I'm a bit fuzzy on this, but this is what I understand is happening). However, many distributions do not do this.
This change allows other distributions (e.g. Arch Linux) to successfully build when blas and cblas are installed to the system.

This change also necessitates that Ubuntu users have an explicit installation of cblas, besides what is provided by blas. I tested installing photoview on Ubuntu with this change, and it required that I install `libatlas-base-dev` which provides the explicit cblas.